### PR TITLE
Feat: Create a subscription instance when a user subscribes to a plan

### DIFF
--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -9,6 +9,7 @@ jobs:
   run-spec:
     name: Run Spec
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     services:
       postgres:
         image: postgres:14-alpine

--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -24,6 +24,7 @@ module Api
         )
 
         if result.success?
+          SubscriptionInstances::CreateJob.perform_later(result.subscription)
           render_subscription(result.subscription)
         else
           render_error_response(result)

--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -24,7 +24,7 @@ module Api
         )
 
         if result.success?
-          SubscriptionInstances::CreateJob.perform_later(result.subscription)
+          SubscriptionInstances::CreateJob.perform_later(result.subscription) if result.subscription.active?
           render_subscription(result.subscription)
         else
           render_error_response(result)

--- a/app/jobs/subscription_instances/create_job.rb
+++ b/app/jobs/subscription_instances/create_job.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class SubscriptionInstances::CreateJob < ApplicationJob
+  queue_as 'billing'
+
+  def perform(subscription)
+    result = SubscriptionInstances::CreateService.new(subscription: subscription).call
+
+    result.raise_if_error!
+  end
+end

--- a/app/models/subscription_instance.rb
+++ b/app/models/subscription_instance.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class SubscriptionInstance < ApplicationRecord
+  include PaperTrailTraceable
+
+  belongs_to :subscription
+end

--- a/app/services/subscription_instances/create_service.rb
+++ b/app/services/subscription_instances/create_service.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+module SubscriptionInstances
+  class CreateService < BaseService
+    INTERVALS_COINCIDE_WITH_SUBSCRIPTION_START = %i[
+      weekly
+      monthly
+      yearly
+      quarterly
+    ]
+    def initialize(subscription:)
+      super
+
+      @subscription = subscription
+    end
+
+    def call
+      return result unless valid?(subscription:)
+
+      ActiveRecord::Base.transaction do
+        result.subscription_instance = create_subscription_instance
+      end
+
+      result
+    rescue ActiveRecord::RecordInvalid => e
+      result.record_validation_failure!(record: e.record)
+    rescue BaseService::FailedResult => e
+      e.result
+    end
+
+    private
+
+    attr_reader :subscription
+    delegate :customer, :plan, to: :subscription
+
+    def valid?(subscription:)
+      return result.validation_failure!(errors: { subscription: ['is_not_active'] }) unless subscription.active?
+
+      result
+    end
+
+    def create_subscription_instance
+      new_subscription_instance = SubscriptionInstance.new(
+        subscription:,
+        started_at:,
+        ended_at: nil,
+        is_finalized: false,
+        total_subscription_value: 0
+      )
+
+      begin
+        new_subscription_instance.save!
+
+        new_subscription_instance
+      rescue ActiveRecord::RecordInvalid => e
+        result.record_validation_failure!(record: e.record)
+      end
+    end
+
+    def started_at
+      return subscription.started_at if INTERVALS_COINCIDE_WITH_SUBSCRIPTION_START.include?(plan.interval.to_sym)
+
+      nil
+    end
+
+    def ended_at
+      # depend on billing time of subscription
+      # how do i calculate the ending_at?
+      # is there any existing service that can help me with this?
+      # exmaple:
+      # if subscrription.billing_time == 'anniversary' && plan.interval == 'weekly'
+      #   ending_at = subscription.ending_at + 1.week
+      # else
+      #   ending_at = Time.current.end_of_week
+      # end
+    end
+  end
+end

--- a/db/migrate/20240527123631_create_subscription_instances.rb
+++ b/db/migrate/20240527123631_create_subscription_instances.rb
@@ -1,0 +1,14 @@
+class CreateSubscriptionInstances < ActiveRecord::Migration[7.0]
+  def change
+    create_table :subscription_instances, id: :uuid do |t|
+      t.references :subscription, null: false, foreign_key: true, type: :uuid
+      t.datetime :started_at
+      t.datetime :ended_at
+      t.uuid :pinet_transaction_charge_id
+      t.decimal :total_subscription_value, precision: 30, scale: 5, default: "0.0", null: false
+      t.boolean :is_finalized, default: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_05_02_095122) do
+ActiveRecord::Schema[7.0].define(version: 2024_05_27_123631) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -902,6 +902,18 @@ ActiveRecord::Schema[7.0].define(version: 2024_05_02_095122) do
     t.index ["payment_provider_id"], name: "index_refunds_on_payment_provider_id"
   end
 
+  create_table "subscription_instances", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "subscription_id", null: false
+    t.datetime "started_at"
+    t.datetime "ended_at"
+    t.uuid "pinet_transaction_charge_id"
+    t.decimal "total_subscription_value", precision: 30, scale: 5, default: "0.0", null: false
+    t.boolean "is_finalized", default: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["subscription_id"], name: "index_subscription_instances_on_subscription_id"
+  end
+
   create_table "subscriptions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "customer_id", null: false
     t.uuid "plan_id", null: false
@@ -1114,6 +1126,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_05_02_095122) do
   add_foreign_key "refunds", "payment_provider_customers"
   add_foreign_key "refunds", "payment_providers"
   add_foreign_key "refunds", "payments"
+  add_foreign_key "subscription_instances", "subscriptions"
   add_foreign_key "subscriptions", "customers"
   add_foreign_key "subscriptions", "plans"
   add_foreign_key "taxes", "organizations"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_05_27_123631) do
+ActiveRecord::Schema[7.0].define(version: 2024_05_31_075016) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"

--- a/spec/factories/subscription_instances.rb
+++ b/spec/factories/subscription_instances.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :subscription_instance do
+    subscription
+
+    is_finalized { false }
+  end
+end

--- a/spec/jobs/subscription_instances/create_job_spec.rb
+++ b/spec/jobs/subscription_instances/create_job_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+RSpec.describe SubscriptionInstances::CreateJob, type: :job do
+  let(:subscription) { create(:subscription) }
+
+  let(:subscription_instance_service) { instance_double(SubscriptionInstances::CreateService) }
+  let(:result) { BaseService::Result.new }
+
+  it 'calls the subscription instance service' do
+    allow(SubscriptionInstances::CreateService).to receive(:new)
+      .with(subscription:)
+      .and_return(subscription_instance_service)
+    allow(subscription_instance_service).to receive(:call)
+      .and_return(result)
+
+    described_class.perform_now(subscription)
+
+    expect(SubscriptionInstances::CreateService).to have_received(:new)
+    expect(subscription_instance_service).to have_received(:call)
+  end
+
+  context 'when reccisult is a failure' do
+    let(:result) do
+      BaseService::Result.new.validation_failure!(errors: { subscription: ['is_not_active'] })
+    end
+
+    let(:subscription) { create(:subscription, :pending) }
+
+    it 'raises an error' do
+      allow(SubscriptionInstances::CreateService).to receive(:new)
+        .with(subscription:)
+        .and_return(subscription_instance_service)
+      allow(subscription_instance_service).to receive(:call)
+        .and_return(result)
+
+      expect do
+        described_class.perform_now(subscription)
+      end.to raise_error(BaseService::FailedResult)
+
+      expect(SubscriptionInstances::CreateService).to have_received(:new)
+      expect(subscription_instance_service).to have_received(:call)
+    end
+  end
+end

--- a/spec/jobs/subscription_instances/create_job_spec.rb
+++ b/spec/jobs/subscription_instances/create_job_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe SubscriptionInstances::CreateJob, type: :job do
     expect(subscription_instance_service).to have_received(:call)
   end
 
-  context 'when reccisult is a failure' do
+  context 'when result is a failure' do
     let(:result) do
       BaseService::Result.new.validation_failure!(errors: { subscription: ['is_not_active'] })
     end

--- a/spec/models/subscription_instance_spec.rb
+++ b/spec/models/subscription_instance_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SubscriptionInstance, type: :model do
+  subject(:subscription_instance) { create(:subscription_instance, subscription:) }
+
+  let(:subscription) { create(:subscription) }
+
+  it 'is valid with valid attributes' do
+    expect(subscription_instance).to be_valid
+  end
+
+  it 'is not valid without a subscription' do
+    subscription_instance.subscription = nil
+    expect(subscription_instance).not_to be_valid
+  end
+end

--- a/spec/services/subscription_instances/create_service_spec.rb
+++ b/spec/services/subscription_instances/create_service_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe SubscriptionInstances::CreateService, type: :service do
           expect(result).to be_success
 
           subscription_instance = result.subscription_instance
-          expect(subscription_instance.started_at).to eq(subscription.started_at)
+          expect(subscription_instance.started_at.to_i).to eq(subscription.started_at.to_i)
         end
       end
     end

--- a/spec/services/subscription_instances/create_service_spec.rb
+++ b/spec/services/subscription_instances/create_service_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SubscriptionInstances::CreateService, type: :service do
+  subject(:create_service) { described_class.new(subscription:) }
+
+  let(:subscription) { create(:subscription, plan:) }
+  let(:plan) { create(:plan, interval: 'weekly') }
+
+  describe '#call' do
+    context 'when the subscription is valid' do
+      it 'create a subscription instance' do
+        result = create_service.call
+
+        aggregate_failures do
+          expect(result).to be_success
+
+          subscription_instance = result.subscription_instance
+          expect(subscription_instance.started_at).to eq(subscription.started_at)
+        end
+      end
+    end
+
+    context 'when the subscription is not active' do
+      let(:subscription) { create(:subscription, :pending) }
+
+      it 'returns an error' do
+        result = create_service.call
+
+        aggregate_failures do
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(result.error.messages[:subscription]).to eq(['is_not_active'])
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Motivation / Background
- User story: https://thepressingly.atlassian.net/browse/PINET-288
- GetLago+ Design and Integration Ideation: https://docs.google.com/document/d/1tzYX_JUdNyxUN2i2rOzSWx0U9tO1Oug4oQaJdfRTH0I/edit

*This Pull Request has been created because:*
- A subscription instance should be created when a user subscribes to a plan

### Detail

*This Pull Request changes:*

-  Migration to create a `Subscription Instance` model
-  Service `SubscriptionInstances::CreateService` to create subscription instance from a subscription
-  Background job `SubscriptionIntances::CreateJob`

### Additional information
- Database design for subscription instance:
<img width="696" alt="image" src="https://github.com/Pressingly/lago-api/assets/45629756/ba6652fb-cd61-4745-9610-c68f6b61eb5b">

*TIP: Provide additional information such as screenshots, benchmarks, reference to other repositories or alternative solutions*

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.