### PR TITLE
Update database design for subscription instance and subscription instance item

### DIFF
--- a/app/models/subscription_instance.rb
+++ b/app/models/subscription_instance.rb
@@ -5,4 +5,12 @@ class SubscriptionInstance < ApplicationRecord
 
   belongs_to :subscription
   has_many :subscription_instance_items, dependent: :destroy
+
+  STATUSES = {
+    pending: 'pending',
+    active: 'active',
+    finalized: 'finalized'
+  }.freeze
+
+  enum status: STATUSES
 end

--- a/app/services/subscription_instance_items/create_service.rb
+++ b/app/services/subscription_instance_items/create_service.rb
@@ -2,9 +2,9 @@
 
 module SubscriptionInstanceItems
   class CreateService < BaseService
-    def initialize(subscription_instance:, fee_amount_cents:, charge_type:, code: nil)
+    def initialize(subscription_instance:, fee_amount:, charge_type:, code: nil)
       @subscription_instance = subscription_instance
-      @fee_amount_cents = fee_amount_cents
+      @fee_amount = fee_amount
       @charge_type = charge_type
       @code = code
 
@@ -13,7 +13,7 @@ module SubscriptionInstanceItems
 
     def call
       result.subscription_instance_item = subscription_instance.subscription_instance_items.create!(
-        fee_amount_cents:,
+        fee_amount:,
         charge_type:,
         code:
       )
@@ -27,6 +27,6 @@ module SubscriptionInstanceItems
 
     private
 
-    attr_reader :subscription_instance, :fee_amount_cents, :charge_type, :code
+    attr_reader :subscription_instance, :fee_amount, :charge_type, :code
   end
 end

--- a/db/migrate/20240527123631_create_subscription_instances.rb
+++ b/db/migrate/20240527123631_create_subscription_instances.rb
@@ -5,8 +5,9 @@ class CreateSubscriptionInstances < ActiveRecord::Migration[7.0]
       t.datetime :started_at
       t.datetime :ended_at
       t.uuid :pinet_transaction_charge_id
-      t.decimal :total_subscription_value, precision: 30, scale: 5, default: "0.0", null: false
-      t.boolean :is_finalized, default: false
+      t.decimal :total_amount, precision: 30, scale: 15, default: "0.0", null: false
+      t.string :status, null: false
+      t.integer :version_number, default: 0, null: false
 
       t.timestamps
     end

--- a/db/migrate/20240527123631_create_subscription_instances.rb
+++ b/db/migrate/20240527123631_create_subscription_instances.rb
@@ -4,7 +4,7 @@ class CreateSubscriptionInstances < ActiveRecord::Migration[7.0]
       t.references :subscription, null: false, foreign_key: true, type: :uuid
       t.datetime :started_at
       t.datetime :ended_at
-      t.uuid :pinet_transaction_charge_id
+      t.uuid :pinet_subscription_charge_id
       t.decimal :total_amount, precision: 30, scale: 15, default: "0.0", null: false
       t.string :status, null: false
       t.integer :version_number, default: 0, null: false

--- a/db/migrate/20240605095652_create_subscription_instance_items.rb
+++ b/db/migrate/20240605095652_create_subscription_instance_items.rb
@@ -2,7 +2,7 @@ class CreateSubscriptionInstanceItems < ActiveRecord::Migration[7.0]
   def change
     create_table :subscription_instance_items, id: :uuid do |t|
       t.references :subscription_instance, null: false, foreign_key: true, type: :uuid
-      t.bigint :fee_amount_cents, default: 0, null: false
+      t.decimal :fee_amount, precision: 30, scale: 15, default: "0.0", null: false
       t.string :charge_type, null: false
       t.string :code
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -917,7 +917,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_06_05_095652) do
     t.uuid "subscription_id", null: false
     t.datetime "started_at"
     t.datetime "ended_at"
-    t.uuid "pinet_transaction_charge_id"
+    t.uuid "pinet_subscription_charge_id"
     t.decimal "total_amount", precision: 30, scale: 15, default: "0.0", null: false
     t.string "status", null: false
     t.integer "version_number", default: 0, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -905,7 +905,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_06_05_095652) do
 
   create_table "subscription_instance_items", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "subscription_instance_id", null: false
-    t.bigint "fee_amount_cents", default: 0, null: false
+    t.decimal "fee_amount", precision: 30, scale: 15, default: "0.0", null: false
     t.string "charge_type", null: false
     t.string "code"
     t.datetime "created_at", null: false
@@ -918,8 +918,9 @@ ActiveRecord::Schema[7.0].define(version: 2024_06_05_095652) do
     t.datetime "started_at"
     t.datetime "ended_at"
     t.uuid "pinet_transaction_charge_id"
-    t.decimal "total_subscription_value", precision: 30, scale: 5, default: "0.0", null: false
-    t.boolean "is_finalized", default: false
+    t.decimal "total_amount", precision: 30, scale: 15, default: "0.0", null: false
+    t.string "status", null: false
+    t.integer "version_number", default: 0, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["subscription_id"], name: "index_subscription_instances_on_subscription_id"

--- a/spec/factories/subscription_instance_items.rb
+++ b/spec/factories/subscription_instance_items.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :subscription_instance_item do
     subscription_instance
-    fee_amount_cents { 0 }
+    fee_amount { 0 }
     charge_type { "base_charge" }
     code { nil }
   end

--- a/spec/factories/subscription_instances.rb
+++ b/spec/factories/subscription_instances.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :subscription_instance do
     subscription
-
-    is_finalized { false }
+    version_number { 0 }
+    status { 'active' }
   end
 end

--- a/spec/services/subscription_instance_items/create_service_spec.rb
+++ b/spec/services/subscription_instance_items/create_service_spec.rb
@@ -4,10 +4,10 @@ require 'rails_helper'
 
 RSpec.describe SubscriptionInstanceItems::CreateService do
   let(:subscription_instance) { create(:subscription_instance) }
-  let(:fee_amount_cents) { 1000 }
+  let(:fee_amount) { 1000 }
   let(:charge_type) { 'base_charge' }
   let(:code) { nil }
-  let(:service) { described_class.new(subscription_instance:, fee_amount_cents:, charge_type:, code:) }
+  let(:service) { described_class.new(subscription_instance:, fee_amount:, charge_type:, code:) }
 
   describe '#call' do
     context 'with valid parameters' do
@@ -15,7 +15,7 @@ RSpec.describe SubscriptionInstanceItems::CreateService do
         result = service.call
         expect(result.subscription_instance_item).to be_a(SubscriptionInstanceItem)
         expect(result.subscription_instance_item.charge_type).to eq(charge_type)
-        expect(result.subscription_instance_item.fee_amount_cents).to eq(fee_amount_cents)
+        expect(result.subscription_instance_item.fee_amount).to eq(fee_amount)
       end
     end
 

--- a/spec/services/subscription_instances/create_service_spec.rb
+++ b/spec/services/subscription_instances/create_service_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe SubscriptionInstances::CreateService, type: :service do
 
         aggregate_failures do
           expect(result).to be_success
+          fee_amount = plan.amount.currency.subunit_to_unit
 
           subscription_instance = result.subscription_instance
           expect(subscription_instance.started_at.to_i).to eq(subscription.started_at.to_i)
@@ -23,8 +24,8 @@ RSpec.describe SubscriptionInstances::CreateService, type: :service do
           subscription_instance_items = subscription_instance.subscription_instance_items
           expect(subscription_instance_items.count).to eq(1)
 
-          expect(subscription_instance_items.first.fee_amount_cents).to eq(amount_cents)
-          expect(subscription_instance.total_subscription_value).to eq(amount_cents / 100.0)
+          expect(subscription_instance_items.first.fee_amount).to eq(fee_amount)
+          expect(subscription_instance.total_amount).to eq(fee_amount)
         end
       end
     end


### PR DESCRIPTION
# Motivation / Background

- After discussing with a Dale on [Story Technical Design: PINET-036 Subscription Instance](https://docs.google.com/document/d/1S6e6DWKXaPXTZZsKGgyawpuoPY-p1PPv_p3XLIFcXqo/edit), there are some changes in the design for subscription instance table and subscription instance item table

# Detail

- Use decimal(precision: 30, scale: 15) for fee_amount and total_amount in the subscription_instance_item and subscription_instance tables, respectively.
- Remove the is_finalized column from the subscription_instance table. Use the status column to indicate if a subscription instance is finalized.
