### PR TITLE
Fix/pinet 420 external customer id instead of customer

### DIFF
--- a/packs/publisher_portal/app/controllers/v1/entitlement/authorization_controller.rb
+++ b/packs/publisher_portal/app/controllers/v1/entitlement/authorization_controller.rb
@@ -33,7 +33,7 @@ module V1
 
       def authorization_params
         params.permit(
-          :externalUserId,
+          :externalCustomerId,
           :publisherId,
           :actionName,
           :timestamp,

--- a/packs/publisher_portal/app/controllers/v1/entitlement/authorization_controller.rb
+++ b/packs/publisher_portal/app/controllers/v1/entitlement/authorization_controller.rb
@@ -70,7 +70,7 @@ module V1
 
       def success_response(code: 200, message: "OK", extra: {})
         {
-          status: "Alow",
+          status: "Allow",
           code: code,
           message: message,
           extra: extra

--- a/packs/publisher_portal/app/controllers/v1/entitlement/authorization_controller.rb
+++ b/packs/publisher_portal/app/controllers/v1/entitlement/authorization_controller.rb
@@ -33,7 +33,7 @@ module V1
 
       def authorization_params
         params.permit(
-          :userId,
+          :externalUserId,
           :publisherId,
           :actionName,
           :timestamp,

--- a/packs/publisher_portal/app/services/authorization/authorize_service.rb
+++ b/packs/publisher_portal/app/services/authorization/authorize_service.rb
@@ -11,9 +11,10 @@ module Authorization
 
     def call
       authorized_resp = client.is_authorized(payload)
-      plans = get_plans_by_policies(authorized_resp[:determining_policies].map { |p| p[:policy_id] })
+      policies = authorized_resp.determining_policies.map { |p| p.policy_id }
+      plans = get_plans_by_policies(policies)
       resp = {
-        is_authorized: authorized_resp[:decision] == 'ALLOW',
+        is_authorized: authorized_resp.decision == 'ALLOW',
         subscription_plan: nil
       }
 
@@ -21,7 +22,7 @@ module Authorization
         resp[:is_authorized] = false
       end
 
-      if authorized_resp[:decision] == 'ALLOW'
+      if authorized_resp.decision == 'ALLOW'
         best_plan = select_the_best_plan(plans)
         resp[:subscription_plan] = best_plan
       end

--- a/packs/publisher_portal/app/services/authorization/authorize_validator.rb
+++ b/packs/publisher_portal/app/services/authorization/authorize_validator.rb
@@ -2,13 +2,13 @@ module Authorization
   class AuthorizeValidator
     include ActiveModel::Model
 
-    attr_accessor :user_id, :publisher_id, :action_name, :context, :resource, :timestamp
+    attr_accessor :external_user_id, :publisher_id, :action_name, :context, :resource, :timestamp
 
-    validates :user_id, :publisher_id, :action_name, :timestamp, presence: true
+    validates :external_user_id, :publisher_id, :action_name, :timestamp, presence: true
 
     validate :resource_validations
     def initialize(params)
-      @user_id = params[:userId]
+      @external_user_id = params[:externalUserId]
       @publisher_id = params[:publisherId]
       @action_name = params[:actionName]
       @context = params[:context]

--- a/packs/publisher_portal/app/services/authorization/authorize_validator.rb
+++ b/packs/publisher_portal/app/services/authorization/authorize_validator.rb
@@ -2,13 +2,13 @@ module Authorization
   class AuthorizeValidator
     include ActiveModel::Model
 
-    attr_accessor :external_user_id, :publisher_id, :action_name, :context, :resource, :timestamp
+    attr_accessor :external_customer_id, :publisher_id, :action_name, :context, :resource, :timestamp
 
-    validates :external_user_id, :publisher_id, :action_name, :timestamp, presence: true
+    validates :external_customer_id, :publisher_id, :action_name, :timestamp, presence: true
 
     validate :resource_validations
     def initialize(params)
-      @external_user_id = params[:externalUserId]
+      @external_customer_id = params[:externalCustomerId]
       @publisher_id = params[:publisherId]
       @action_name = params[:actionName]
       @context = params[:context]

--- a/packs/publisher_portal/app/services/consumption_event/emit_service.rb
+++ b/packs/publisher_portal/app/services/consumption_event/emit_service.rb
@@ -59,7 +59,7 @@ module ConsumptionEvent
     end
 
     def create_params(plan_id, req_payload)
-      customer = Customer.find_by(external_id: req_payload["externalUserId"])
+      customer = Customer.find_by(external_id: req_payload["externalCustomerId"])
       subscription = Subscription.find_by(plan_id: plan_id, customer_id: customer.id)
 
       # TODO: a plan can have multiple billable metrics. Do we emit one consumption event per billable metric?

--- a/packs/publisher_portal/app/services/consumption_event/emit_service.rb
+++ b/packs/publisher_portal/app/services/consumption_event/emit_service.rb
@@ -59,7 +59,7 @@ module ConsumptionEvent
     end
 
     def create_params(plan_id, req_payload)
-      customer = Customer.find_by(id: req_payload["userId"])
+      customer = Customer.find_by(external_id: req_payload["externalUserId"])
       subscription = Subscription.find_by(plan_id: plan_id, customer_id: customer.id)
 
       # TODO: a plan can have multiple billable metrics. Do we emit one consumption event per billable metric?

--- a/packs/publisher_portal/app/services/entitlement_adapter/converter_service.rb
+++ b/packs/publisher_portal/app/services/entitlement_adapter/converter_service.rb
@@ -4,7 +4,7 @@ module EntitlementAdapter
       @payload = payload
       @policy_store = PolicyStore.find_by(id: policy_store_id)
 
-      @external_user_id = payload["externalUserId"]
+      @external_customer_id = payload["externalCustomerId"]
       super
     end
 
@@ -13,7 +13,7 @@ module EntitlementAdapter
         policy_store_id: get_policy_store_id,
         principal: {
           entity_type: principal_entity_type,
-          entity_id: @external_user_id,
+          entity_id: @external_customer_id,
         },
         action: {
           action_type: action_type,
@@ -31,7 +31,7 @@ module EntitlementAdapter
             {
               identifier: {
                 entity_type: principal_entity_type,
-                entity_id: @external_user_id,
+                entity_id: @external_customer_id,
               },
               parents: map_plans_to_principals
             },
@@ -115,9 +115,9 @@ module EntitlementAdapter
     end
 
     def all_plans_by_user
-      return [] if @external_user_id.nil?
+      return [] if @external_customer_id.nil?
 
-      customer_id = Customer.find_by(external_id: @external_user_id)&.id
+      customer_id = Customer.find_by(external_id: @external_customer_id)&.id
 
       Plan.joins(:subscriptions).where(subscriptions: { customer_id: customer_id }).uniq
     end

--- a/packs/publisher_portal/app/services/entitlement_adapter/converter_service.rb
+++ b/packs/publisher_portal/app/services/entitlement_adapter/converter_service.rb
@@ -20,7 +20,7 @@ module EntitlementAdapter
           action_id: get_payload_action,
         },
         resource: {
-          entity_type: resource_entity_type,
+          entity_type: article_entity_type,
           entity_id: resource_type,
         },
         context: {
@@ -39,6 +39,11 @@ module EntitlementAdapter
               identifier: {
                 entity_type: article_entity_type,
                 entity_id: resource_type,
+              },
+              attributes: {
+                category: {
+                  string: resource_category
+                }
               },
               parents: [
                 {
@@ -82,6 +87,10 @@ module EntitlementAdapter
 
     def article_entity_type
       "#{namespace}::Article"
+    end
+
+    def resource_category
+      payload["resource"]["category"]
     end
 
     def action_type

--- a/packs/publisher_portal/app/services/subscription_charges/create_service.rb
+++ b/packs/publisher_portal/app/services/subscription_charges/create_service.rb
@@ -15,7 +15,6 @@ module SubscriptionCharges
         .find_by(subscriptions: { id: subscription_instance.subscription_id})
       plan = Plan.joins(:subscriptions)
         .find_by(subscriptions: {id: subscription_instance.subscription_id})
-      puts "subscription_instance: #{subscription_instance.inspect}"
 
       stub.create_subscription_charge(Revenue::CreateSubscriptionChargeReq.new(
         {

--- a/packs/publisher_portal/spec/requests/v1/entitlement/authorization_controller_spec.rb
+++ b/packs/publisher_portal/spec/requests/v1/entitlement/authorization_controller_spec.rb
@@ -23,13 +23,13 @@ RSpec.describe V1::Entitlement::AuthorizationController, type: :request do
     end
 
     let(:is_authorized_resp) {
-      {
+      OpenStruct.new(
         decision: "ALLOW",
         determining_policies: [
-          {policy_id: policy.cedar_policy_id},
+          OpenStruct.new(policy_id: policy.cedar_policy_id),
         ],
         errors: []
-      }
+      )
     }
     let(:avp_client) do
       instance_double(Aws::VerifiedPermissions::Client, is_authorized: is_authorized_resp)
@@ -37,7 +37,7 @@ RSpec.describe V1::Entitlement::AuthorizationController, type: :request do
 
     let(:base_params) do
       {
-        userId: customer.id,
+        externalUserId: customer.external_id,
         publisherId: "Publisher id we create for the publisher when they are onboarded",
         actionName: "read",
         context: {},
@@ -75,11 +75,13 @@ RSpec.describe V1::Entitlement::AuthorizationController, type: :request do
 
     context 'when no Cedar return unauthorized' do
       let(:is_authorized_resp) {
-        {
+        OpenStruct.new(
           decision: "DENY",
-          determining_policies: [],
+          determining_policies: [
+            OpenStruct.new(policy_id: policy.cedar_policy_id),
+          ],
           errors: []
-        }
+        )
       }
       let(:avp_client) do
         instance_double(Aws::VerifiedPermissions::Client, is_authorized: is_authorized_resp)
@@ -92,8 +94,8 @@ RSpec.describe V1::Entitlement::AuthorizationController, type: :request do
       end
     end
 
-    context 'when no userId is provided' do
-      let(:params) { base_params.except(:userId) }
+    context 'when no externalUserId is provided' do
+      let(:params) { base_params.except(:externalUserId) }
 
       it 'returns a 422 status code' do
         post('/v1/entitlement/authorize', params: params.to_json, headers: headers)

--- a/packs/publisher_portal/spec/requests/v1/entitlement/authorization_controller_spec.rb
+++ b/packs/publisher_portal/spec/requests/v1/entitlement/authorization_controller_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe V1::Entitlement::AuthorizationController, type: :request do
 
     let(:base_params) do
       {
-        externalUserId: customer.external_id,
+        externalCustomerId: customer.external_id,
         publisherId: "Publisher id we create for the publisher when they are onboarded",
         actionName: "read",
         context: {},
@@ -94,8 +94,8 @@ RSpec.describe V1::Entitlement::AuthorizationController, type: :request do
       end
     end
 
-    context 'when no externalUserId is provided' do
-      let(:params) { base_params.except(:externalUserId) }
+    context 'when no externalCustomerId is provided' do
+      let(:params) { base_params.except(:externalCustomerId) }
 
       it 'returns a 422 status code' do
         post('/v1/entitlement/authorize', params: params.to_json, headers: headers)

--- a/packs/publisher_portal/spec/services/authorization/authorize_validator_spec.rb
+++ b/packs/publisher_portal/spec/services/authorization/authorize_validator_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Authorization::AuthorizeValidator, type: :model do
   let(:valid_attributes) do
     {
-      userId: 'user1',
+      externalUserId: 'user1',
       publisherId: 'publisher1',
       actionName: 'action1',
       context: {},
@@ -19,7 +19,7 @@ RSpec.describe Authorization::AuthorizeValidator, type: :model do
     end
 
     it 'is not valid without a user_id' do
-      validator = described_class.new(valid_attributes.except(:userId))
+      validator = described_class.new(valid_attributes.except(:externalUserId))
       expect(validator).not_to be_valid
     end
 

--- a/packs/publisher_portal/spec/services/authorization/authorize_validator_spec.rb
+++ b/packs/publisher_portal/spec/services/authorization/authorize_validator_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Authorization::AuthorizeValidator, type: :model do
   let(:valid_attributes) do
     {
-      externalUserId: 'user1',
+      externalCustomerId: 'user1',
       publisherId: 'publisher1',
       actionName: 'action1',
       context: {},
@@ -19,7 +19,7 @@ RSpec.describe Authorization::AuthorizeValidator, type: :model do
     end
 
     it 'is not valid without a user_id' do
-      validator = described_class.new(valid_attributes.except(:externalUserId))
+      validator = described_class.new(valid_attributes.except(:externalCustomerId))
       expect(validator).not_to be_valid
     end
 

--- a/packs/publisher_portal/spec/services/consumption_event/emit_service_spec.rb
+++ b/packs/publisher_portal/spec/services/consumption_event/emit_service_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe ConsumptionEvent::EmitService, type: :service do
   let(:policy) { create(:authorization_policy, plan_id: plan.id) }
   let(:subscription_plan) { plan.attributes }
   let(:customer) { create(:customer) }
-  let(:request) { instance_double('ActionDispatch::Request', body: StringIO.new("{\"userId\": \"#{customer.id}\"}"), user_agent: 'TestAgent', remote_ip: '127.0.0.1') }
+  let(:request) { instance_double('ActionDispatch::Request', body: StringIO.new("{\"externalUserId\": \"#{customer.external_id}\"}"), user_agent: 'TestAgent', remote_ip: '127.0.0.1') }
   let(:subscription) { create(:subscription, plan: plan, customer_id: customer.id) }
   let(:billable_metric) { create(:billable_metric, organization: organization) }
   let(:charge) { create(:standard_charge, plan: plan, billable_metric: billable_metric) }

--- a/packs/publisher_portal/spec/services/consumption_event/emit_service_spec.rb
+++ b/packs/publisher_portal/spec/services/consumption_event/emit_service_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe ConsumptionEvent::EmitService, type: :service do
   let(:policy) { create(:authorization_policy, plan_id: plan.id) }
   let(:subscription_plan) { plan.attributes }
   let(:customer) { create(:customer) }
-  let(:request) { instance_double('ActionDispatch::Request', body: StringIO.new("{\"externalUserId\": \"#{customer.external_id}\"}"), user_agent: 'TestAgent', remote_ip: '127.0.0.1') }
+  let(:request) { instance_double('ActionDispatch::Request', body: StringIO.new("{\"externalCustomerId\": \"#{customer.external_id}\"}"), user_agent: 'TestAgent', remote_ip: '127.0.0.1') }
   let(:subscription) { create(:subscription, plan: plan, customer_id: customer.id) }
   let(:billable_metric) { create(:billable_metric, organization: organization) }
   let(:charge) { create(:standard_charge, plan: plan, billable_metric: billable_metric) }

--- a/packs/publisher_portal/spec/services/entitlement_adapter/converter_service_spec.rb
+++ b/packs/publisher_portal/spec/services/entitlement_adapter/converter_service_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe EntitlementAdapter::ConverterService, type: :service do
   subject(:converter_service) { described_class.new(payload:, policy_store_id:) }
 
   let(:base_payload) {
-    {"externalUserId" => "012646d9-1b82-43e3-8ef9-60c538091149",
+    {"externalCustomerId" => "012646d9-1b82-43e3-8ef9-60c538091149",
      "publisherId" => "Publisher id we create for the publisher when they are onboarded",
      "actionName" => "read",
      "context" => {},
@@ -28,8 +28,8 @@ RSpec.describe EntitlementAdapter::ConverterService, type: :service do
       policy_store
     end
 
-    context 'when externalUserId exist' do
-      it 'principal entity id is the same with externalUserId in payload' do
+    context 'when externalCustomerId exist' do
+      it 'principal entity id is the same with externalCustomerId in payload' do
         result = converter_service.call
         aggregate_failures do
           expect(result[:principal][:entity_id]).to eq("012646d9-1b82-43e3-8ef9-60c538091149")
@@ -37,8 +37,8 @@ RSpec.describe EntitlementAdapter::ConverterService, type: :service do
       end
     end
 
-    context 'when externalUserId does not exist' do
-      let(:payload) { base_payload.except("externalUserId") }
+    context 'when externalCustomerId does not exist' do
+      let(:payload) { base_payload.except("externalCustomerId") }
 
       it 'principal entity id is nil' do
         result = converter_service.call

--- a/packs/publisher_portal/spec/services/entitlement_adapter/converter_service_spec.rb
+++ b/packs/publisher_portal/spec/services/entitlement_adapter/converter_service_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe EntitlementAdapter::ConverterService, type: :service do
   subject(:converter_service) { described_class.new(payload:, policy_store_id:) }
 
   let(:base_payload) {
-    {"userId" => "012646d9-1b82-43e3-8ef9-60c538091149",
+    {"externalUserId" => "012646d9-1b82-43e3-8ef9-60c538091149",
      "publisherId" => "Publisher id we create for the publisher when they are onboarded",
      "actionName" => "read",
      "context" => {},
@@ -28,8 +28,8 @@ RSpec.describe EntitlementAdapter::ConverterService, type: :service do
       policy_store
     end
 
-    context 'when userId exist' do
-      it 'principal entity id is the same with userId in payload' do
+    context 'when externalUserId exist' do
+      it 'principal entity id is the same with externalUserId in payload' do
         result = converter_service.call
         aggregate_failures do
           expect(result[:principal][:entity_id]).to eq("012646d9-1b82-43e3-8ef9-60c538091149")
@@ -37,8 +37,8 @@ RSpec.describe EntitlementAdapter::ConverterService, type: :service do
       end
     end
 
-    context 'when userId does not exist' do
-      let(:payload) { base_payload.except("userId") }
+    context 'when externalUserId does not exist' do
+      let(:payload) { base_payload.except("externalUserId") }
 
       it 'principal entity id is nil' do
         result = converter_service.call

--- a/packs/publisher_portal/spec/services/subscription_charges/create_service_spec.rb
+++ b/packs/publisher_portal/spec/services/subscription_charges/create_service_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 require 'revenue.service_services_pb'
 
 RSpec.describe SubscriptionCharges::CreateService do
-  subject(:create_service) { described_class.new(subscription: subscription) }
+  subject(:create_service) { described_class.new(subscription_instance: sub_instance) }
 
   let(:subscription) { create(:subscription) }
   let(:sub_instance) { create(:subscription_instance) }

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -18,13 +18,13 @@ paths:
             schema:
               type: object
               required:
-                - externalUserId
+                - externalCustomerId
                 - publisherId
                 - actionName
                 - resource
                 - timestamp
               properties:
-                externalUserId:
+                externalCustomerId:
                   type: string
                 publisherId:
                   type: string

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -18,13 +18,13 @@ paths:
             schema:
               type: object
               required:
-                - userId
+                - externalUserId
                 - publisherId
                 - actionName
                 - resource
                 - timestamp
               properties:
-                userId:
+                externalUserId:
                   type: string
                 publisherId:
                   type: string


### PR DESCRIPTION
# Motivation / Background

Update `userId` input payload with `externalUserId` (getLago customer `external_id`) and put `category` in resource query for AVP

*This Pull Request has been created because:*
Reasons for the change

- Publisher Core don't know customer id in GetLago, only knows its `external_id`
- Without `category`, every request would be allowed as long the the user has just 1 subscription

*This Pull Request changes:*
- Replace `user_id` with `external_id`
- Add `category` for resource in AVP `is_authorized` params

List of things you do in this PR
- [x] Replace `user_id` with `external_id`
- [x] Add `category` for resource in AVP `is_authorized` params

# Additional information

*TIP: Provide additional information such as screenshots, benchmarks, reference to other repositories or alternative solutions*

# Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.