### PR TITLE
Add organization_id to PolicyStore table

### DIFF
--- a/db/publisher_portal_migrate/20240715031950_add_organization_id_to_policy_stores.rb
+++ b/db/publisher_portal_migrate/20240715031950_add_organization_id_to_policy_stores.rb
@@ -1,0 +1,5 @@
+class AddOrganizationIdToPolicyStores < ActiveRecord::Migration[7.0]
+  def change
+    add_column :policy_stores, :organization_id, :string
+  end
+end

--- a/db/publisher_portal_schema.rb
+++ b/db/publisher_portal_schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_06_15_093122) do
+ActiveRecord::Schema[7.0].define(version: 2024_07_15_031950) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -27,6 +27,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_06_15_093122) do
     t.json "schema"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "organization_id"
   end
 
 end

--- a/packs/publisher_portal/spec/requests/v1/entitlement/authorization_controller_spec.rb
+++ b/packs/publisher_portal/spec/requests/v1/entitlement/authorization_controller_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe V1::Entitlement::AuthorizationController, type: :request do
     let(:subscription) { create(:subscription, plan: plan, customer_id: customer.id) }
     let(:billable_metric) { create(:billable_metric, organization: organization) }
     let(:charge) { create(:standard_charge, plan: plan, billable_metric: billable_metric) }
-    let(:policy_store) { create(:policy_store) }
+    let(:policy_store) { create(:policy_store, organization_id: organization.id) }
     let(:policy_store_id) { policy_store.id }
     let(:headers) do
       {

--- a/spec/scenarios/billable_metrics/unique_count_spec.rb
+++ b/spec/scenarios/billable_metrics/unique_count_spec.rb
@@ -9,7 +9,7 @@ describe 'Aggregation - Unique Count Scenarios', :scenarios, type: :request, tra
   let(:plan) { create(:plan, organization:, amount_cents: 0) }
   let(:billable_metric) { create(:unique_count_billable_metric, :recurring, organization:) }
   let(:charge) do
-    create(:standard_charge, plan:, billable_metric:, properties: { amount: '1', grouped_by: %w[key_1 key_2 key_3] })
+    create(:standard_charge, plan:, billable_metric:, properties: {amount: '1', grouped_by: %w[key_1 key_2 key_3]})
   end
 
   before { charge }
@@ -109,6 +109,7 @@ describe 'Aggregation - Unique Count Scenarios', :scenarios, type: :request, tra
             code: billable_metric.code,
             transaction_id: SecureRandom.uuid,
             external_subscription_id: subscription.external_id,
+            timestamp: Time.zone.parse('2024-02-01T01:00:00').to_f,
             properties: {
               'item_id' => '001',
               'operation_type' => 'remove',
@@ -129,6 +130,7 @@ describe 'Aggregation - Unique Count Scenarios', :scenarios, type: :request, tra
             code: billable_metric.code,
             transaction_id: SecureRandom.uuid,
             external_subscription_id: subscription.external_id,
+            timestamp: Time.zone.parse('2024-02-02T01:00:00').to_f,
             properties: {
               'item_id' => '001',
               'operation_type' => 'add',
@@ -173,6 +175,7 @@ describe 'Aggregation - Unique Count Scenarios', :scenarios, type: :request, tra
             code: billable_metric.code,
             transaction_id: SecureRandom.uuid,
             external_subscription_id: subscription.external_id,
+            timestamp: Time.zone.parse('2024-02-03T01:00:00').to_f,
             properties: {
               'item_id' => '001',
               'operation_type' => 'remove',
@@ -223,7 +226,7 @@ describe 'Aggregation - Unique Count Scenarios', :scenarios, type: :request, tra
             code: billable_metric.code,
             transaction_id: SecureRandom.uuid,
             external_subscription_id: subscription.external_id,
-            properties: { 'item_id' => 'seat_1' },
+            properties: {'item_id' => 'seat_1'},
           },
         )
 


### PR DESCRIPTION
# Motivation / Background
- Ticket https://thepressingly.atlassian.net/browse/PINET-643

*This Pull Request has been created because:*
Reasons for the change
- Currently, we use the environment variable AUTHENTICATION_POLICY_STORE_ID to identify the policy store for an organization, which does not work when there are multiple organizations in the database. By adding an organization_id column to the PolicyStore table, we can retrieve the policy store ID for each organization.
# Detail

*This Pull Request changes:*

List of things you do in this PR
- Add a migration to include the organization_id column in the PolicyStore table.
- Update `Authorize API` to get a `policy store` based on the `current organization` of the user.
# Additional information

*TIP: Provide additional information such as screenshots, benchmarks, reference to other repositories or alternative solutions*

# Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
